### PR TITLE
Fix ImportError: No module named fs.utils

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -16,6 +16,7 @@ from django.template import Context, Template
 from webob import Response
 
 from celery import task
+from fs.copy import copy_fs
 from fs.tempfs import TempFS
 from djpyfs import djpyfs
 
@@ -137,9 +138,6 @@ def updoad_all_content(temp_directory, fs):
     This standalone function handles the bulk upload of unzipped content.
     """
     if not settings.DJFS.get('type', 'osfs') == "s3fs":
-        # Temporary fix
-        # TODO: find a better solution for ImportError: No module named fs.utils
-        from fs.copy import copy_fs
         copy_fs(temp_directory, fs)
         return
 


### PR DESCRIPTION
This PR fixes `No module named fs.utils` when using the xblock in local.

It changes `copydir` to `copy_fs`, a method that copies the directory inside temp_directory to fs.

Previous work: [PR](https://github.com/eduNEXT/edx_xblock_scorm/pull/7/files)