### PR TITLE
PADV-419 - SCORM xblock migration.

### DIFF
--- a/docs/migration_changes.md
+++ b/docs/migration_changes.md
@@ -1,0 +1,11 @@
+# Migration Changes
+
+Following the Olive migration process, it was time to migrate the Scorm xblock. Because the history of this xblock is confusing, the approach taken to migrate was to test it in the new version, see if it worked and if not, make the necessary changes to make it work.
+
+## Changes applied
+
+Changed celery 'task' decorator for 'shared_task' for the s3_upload task. This change has to do with celery itself, that implemented shared_task as the way to create isolated tasks for a Django app. Also one of the calls of the task was changed from s3_upload() to s3_upload.delay() since it was not executing correctly in a worker with redis.
+
+## Refactoring
+
+The additional changes made to the xblock was some refactoring of the code to adapt it to new Python code standards.


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-419

## Description

This PR aims to add the necessary changes to make the scorm xblock compatible with edx-platform olive version.

## Type of Change

- [x] Make compatibility changes
- [x] Create MD file to justify the reasons behind the changes

## Testing:

- Clone repo on devstack src folder
- Install the xblock in the LMS and CMS containers
- Download a scorm package (you can do so here https://scorm.com/scorm-explained/technical-scorm/golf-examples/?utm_source=google&utm_medium=natural_search)
- Then create a new course with the 'scormxblock' in the advanced modules enabled and create a new unit uploading the package
- Go to the course and verify that the xblock works correctly

## Screenshots:

![image](https://user-images.githubusercontent.com/62396424/234340516-8854e1b0-8dc5-425d-90ca-f414d79a4f7a.png)
![image](https://user-images.githubusercontent.com/62396424/234340636-64b93e6b-e3bf-4956-974f-206c1f97cfbb.png)

## Reviewers

- [ ] @Squirrel18 
- [x] @anfbermudezme 
